### PR TITLE
Update Madminer page URLs

### DIFF
--- a/pages/projects/madminer.md
+++ b/pages/projects/madminer.md
@@ -41,7 +41,6 @@ to be very valuable for inference.
 [![PyPI version](https://badge.fury.io/py/madminer.svg)](https://badge.fury.io/py/madminer)
 [![Documentation Status](https://readthedocs.org/projects/madminer/badge/?version=latest)](https://madminer.readthedocs.io/en/latest/?badge=latest)
 [![CI Status](https://github.com/madminer-tool/madminer/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/madminer-tool/madminer/actions/workflows/ci.yml?query=branch%3Amaster)
-[![Docker pulls](https://img.shields.io/docker/pulls/madminertool/docker-madminer.svg)](https://hub.docker.com/r/madminertool/docker-madminer)
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/madminer-tool/madminer/master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/pages/projects/madminer.md
+++ b/pages/projects/madminer.md
@@ -37,12 +37,12 @@ playfully call this process "mining gold" from the simulator, since this informa
 to be very valuable for inference.
 
 
-[![GitHub](https://img.shields.io/badge/GitHub-555555.svg)](https://github.com/diana-hep/madminer)
+[![GitHub](https://img.shields.io/badge/GitHub-555555.svg)](https://github.com/madminer-tool/madminer)
 [![PyPI version](https://badge.fury.io/py/madminer.svg)](https://badge.fury.io/py/madminer)
 [![Documentation Status](https://readthedocs.org/projects/madminer/badge/?version=latest)](https://madminer.readthedocs.io/en/latest/?badge=latest)
-[![CI Status](https://github.com/diana-hep/madminer/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/diana-hep/madminer/actions/workflows/ci.yml?query=branch%3Amaster)
+[![CI Status](https://github.com/madminer-tool/madminer/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/madminer-tool/madminer/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Docker pulls](https://img.shields.io/docker/pulls/madminertool/docker-madminer.svg)](https://hub.docker.com/r/madminertool/docker-madminer)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/diana-hep/madminer/master)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/madminer-tool/madminer/master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1489147.svg)](https://doi.org/10.5281/zenodo.1489147)


### PR DESCRIPTION
This PR updates the [madminer project page](https://iris-hep.org/projects/madminer.html) URLs, given its recent migration to its own organization ([madminer-tool](https://github.com/madminer-tool)). The migration was done with the logistic help of Kyle (due to permissions), and the "👍🏻 " of all the original authors: Johann, Felix, Kyle and Irina.

Lastly, the _Docker pulls_ badge has been removed, given that the main repo does not provide an image currently.