### PR TITLE
talk: Add Feickert Parsl & funcX Fest 2021 talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -227,3 +227,12 @@ presentations:
   location: Virtual
   focus-area: as
   project: pyhf
+
+- title: 'Distributed statistical inference with pyhf powered by funcX'
+  date: 2021-10-27
+  url: https://parsl-project.org/parslfest2021.html
+  meeting: Parsl & funcX Fest 2021
+  meetingurl: https://parsl-project.org/parslfest2021.html
+  location: Virtual
+  focus-area: as
+  project: pyhf

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -230,7 +230,7 @@ presentations:
 
 - title: 'Distributed statistical inference with pyhf powered by funcX'
   date: 2021-10-27
-  url: https://parsl-project.org/parslfest2021.html
+  url: https://parsl-project.org/parslfest2021-files/feickert-pyhf.pdf
   meeting: Parsl & funcX Fest 2021
   meetingurl: https://parsl-project.org/parslfest2021.html
   location: Virtual


### PR DESCRIPTION
```
* Add pyhf and funcX talk presented at Parsl & funcX Fest 2021 by Matthew Feickert
   - c.f. https://parsl-project.org/parslfest2021.html
```