### PR TITLE
mentor: Add Matthew Feickert as pyhf + Combine project mentor

### DIFF
--- a/_data/fellow_projects/a_pyhf_converter_for_binned_likelihood_models_in_cms_combine.yml
+++ b/_data/fellow_projects/a_pyhf_converter_for_binned_likelihood_models_in_cms_combine.yml
@@ -16,3 +16,4 @@ description: >
 contacts:
 - cranmer
 - alexander-held
+- matthewfeickert


### PR DESCRIPTION
Getting pyhf + Combine working is a high priority pyhf goal (c.f. https://github.com/scikit-hep/pyhf/issues/344) and so having a pyhf core dev team member on the project mentor list would be helpful from the pyhf project point of view. :+1: 

cc @alexander-held This is more meant to signal "happy to help and put time into this", so I hope this doesn't come across as trying to push my way onto something that you already have very well covered. :+1: 