### PR TITLE
talk: Update Feickert talks through January 2024

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -430,3 +430,39 @@ presentations:
     location: Princeton, U.S.A.
     focus-area: as
     project: pyhf
+
+  - title: "Distributing your Science: Turning analyses into scientific tools"
+    date: 2023-09-08
+    url: https://matthewfeickert-talks.github.io/talk-odsl-forum-seminar-2023/
+    meeting: "ORIGINS Data Science Lab Forum"
+    meetingurl: https://matthewfeickert-talks.github.io/talk-odsl-forum-seminar-2023/
+    location: Virtual
+    focus-area: as
+    project:
+
+  - title: "Towards Differentiable Physics Analysis at Scale at the LHC and Beyond"
+    date: 2023-09-18
+    url: https://matthewfeickert-talks.github.io/talk-snolab-seminar-2023/
+    meeting: "SNOLAB Seminar Series"
+    meetingurl: https://matthewfeickert-talks.github.io/talk-snolab-seminar-2023/
+    location: Virtual
+    focus-area: as
+    project:
+
+  - title: "pyhf Tutorial and Exploration"
+    date: 2023-10-11
+    url: https://indico.cern.ch/event/1252095/contributions/5592418/
+    meeting: "PyHEP 2023 Workshop"
+    meetingurl: https://indico.cern.ch/event/1252095/
+    location: Virtual
+    focus-area: as
+    project: pyhf
+
+  - title: "Towards Differentiable Physics Analysis at the High-Luminosity Large Hadron Collider and Beyond"
+    date: 2024-01-31
+    url: https://matthewfeickert-talks.github.io/talk-uc-berkeley-research-seminar-2024/
+    meeting: "UC Berkeley Neyman Seminar"
+    meetingurl: https://events.berkeley.edu/neyman-seminar/event/236154-neyman-seminar-matthew-feickert
+    location: Berkeley, U.S.A.
+    focus-area: as
+    project:


### PR DESCRIPTION
* Add ORIGINS Data Science Lab Forum seminar 2023.
   - c.f. https://matthewfeickert-talks.github.io/talk-odsl-forum-seminar-2023/
* Add SNOLAB seminar 2023.
   - c.f. https://matthewfeickert-talks.github.io/talk-snolab-seminar-2023/
* Add pyhf tutorial at PyHEP 2023.
   - c.f. https://indico.cern.ch/event/1252095/contributions/5592418/
* Add UC Berkeley Neyman seminar 2024
   - c.f. https://matthewfeickert-talks.github.io/talk-uc-berkeley-research-seminar-2024/