### PR TITLE
talk: Add Feickert primary CHEP 2026 talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -521,3 +521,12 @@ presentations:
     location: Denver, U.S.A.
     focus-area: as
     project:
+
+  - title: "HEP Packaging Coordination: Distributing the HEP software ecosystem on conda-forge"
+    date: 2026-05-27
+    url: https://indico.cern.ch/event/1471803/contributions/6966833/
+    meeting: "CHEP 2026 - Conference on Computing in High Energy and Nuclear Physics"
+    meetingurl: https://indico.cern.ch/event/1471803/
+    location: Bangkok, Thailand
+    focus-area: as
+    project:


### PR DESCRIPTION
* Add 'HEP Packaging Coordination: Distributing the HEP software ecosystem on conda-forge' talk given at CHEP 2026.
   - c.f. https://indico.cern.ch/event/1471803/contributions/6966833/