### PR TITLE
Short term fix to remove deprecation warnings from build logs.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,12 @@ exclude:
 
 sass:
   sass_dir: _sass
+  silence_deprecations:
+    - import
+    - global-builtin
+    - color-functions
+    - mixed-decls
+    - slash-div
 
 indico:
   url: https://indico.cern.ch


### PR DESCRIPTION
The fix adds silence_deprecations to the sass: block in [_config.yml](vscode-webview://119h19pcvel2d5af4bns3j9vg65lo1bcd1n7vjle5411km5qi9um/_config.yml), suppressing the five deprecated Sass patterns from Bootstrap 4's vendored SCSS: @import rules, global built-in functions, darken()/lighten() color functions, mixed declarations, and / division syntax.

I supposed the long term fix is to migrate to a new Bootstrap - but that seems a bit daunting at the moment.
