### PR TITLE
fix: Remove duplicate talk entry

### DIFF
--- a/_data/people/kratsg.yml
+++ b/_data/people/kratsg.yml
@@ -49,12 +49,3 @@ presentations:
     challenge-area: agc
     focus-area: as
     project: agc
-
-  - title: "HEP Packaging Coordination: Distributing the HEP software ecosystem on conda-forge"
-    date: 2026-05-27
-    url: https://indico.cern.ch/event/1471803/contributions/6966833/
-    meeting: 28th Conference on Computing in High Energy and Nuclear Physics (CHEP 2026)
-    meetingurl: https://indico.cern.ch/event/1471803/
-    location: Bangkok, Thailand
-    focus-area: as
-    project:


### PR DESCRIPTION
* Talks should be added by the presenter to avoid duplicate entries.
   - c.f. https://github.com/iris-hep/iris-hep.github.io/pull/2794#discussion_r3120452632