### PR TITLE
Add Tai Sakuma to Awkward Array project team

### DIFF
--- a/pages/projects/awkward.md
+++ b/pages/projects/awkward.md
@@ -23,6 +23,7 @@ team:
 - Santam Roy Choudhury
 - ncsmith
 - ManasviGoyal
+- TaiSakuma
 ---
 
 [Awkward Array](https://github.com/scikit-hep/awkward) is a library for nested, variable-sized data, including arbitrary-length lists, records, mixed types, and missing data, using NumPy-like idioms.


### PR DESCRIPTION
Adds my shortname (`TaiSakuma`) to the `team:` list on the Awkward Array project page so I appear on <https://iris-hep.org/projects/awkward.html>.

- Appended `- TaiSakuma` to `team:` in `pages/projects/awkward.md`
- Resolves via the existing `_data/people/TaiSakuma.yml` (shortname `TaiSakuma`); no new people file or photo needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)