### PR TITLE
Add ANRW 2026 publication

### DIFF
--- a/_data/publications/3827937.yml
+++ b/_data/publications/3827937.yml
@@ -1,0 +1,6 @@
+title: "Explainable Routing-Aware Incident Triage from Active Measurements"
+link: https://doi.org/10.1145/3822163.3827937
+date: 2026-07-20
+citation: "Petya Vasileva, Shawn McKee, Alexander Penev, Marian Babik, and Yuval Shavitt. ANRW '26: Proceedings of the 2026 Applied Networking Research Workshop, pages 67-74."
+focus-area: osglhc
+project: osg-networking


### PR DESCRIPTION
add publication metadata for “Explainable Routing-Aware Incident Triage from Active Measurements”